### PR TITLE
Feature/redirect to site url

### DIFF
--- a/Drivers/SEOSettingsPartDriver.cs
+++ b/Drivers/SEOSettingsPartDriver.cs
@@ -5,26 +5,39 @@ using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Localization;
+using System;
 
 namespace Moov2.Orchard.SEO.Drivers
 {
     public class SEOSettingsPartDriver : ContentPartDriver<SEOSettingsPart>
     {
+        #region Dependencies
         private readonly ISignals _signals;
-        private const string TemplateName = "Parts.SEOSettings";
+        #endregion
 
+        #region Constants
+        private const string TemplateName = "Parts.SEOSettings";
+        #endregion
+
+        #region Constructor
         public SEOSettingsPartDriver(ISignals signals)
         {
             _signals = signals;
             T = NullLocalizer.Instance;
         }
+        #endregion
 
+        #region Orchard Properties
         public Localizer T { get; set; }
+        #endregion
 
-        protected override string Prefix {
+        #region Overrides
+        protected override string Prefix
+        {
             get { return "SEOSettings"; }
         }
 
+        #region Editor
         protected override DriverResult Editor(SEOSettingsPart part, dynamic shapeHelper)
         {
             return ContentShape("Parts_SEOSettings_Edit",
@@ -35,14 +48,55 @@ namespace Moov2.Orchard.SEO.Drivers
         protected override DriverResult Editor(SEOSettingsPart part, IUpdateModel updater, dynamic shapeHelper)
         {
             if (updater.TryUpdateModel(part, Prefix, null, null))
+            {
+                ValidateSiteUrl(part);
+                ValidateSiteUrlAndWWWCompatibility(part, updater);
+
                 _signals.Trigger(SEOSettingsPart.CacheKey);
+            }
 
             return Editor(part, shapeHelper);
         }
-
+        #endregion
+        #region Importing
         protected override void Importing(SEOSettingsPart part, ImportContentContext context)
         {
             _signals.Trigger(SEOSettingsPart.CacheKey);
         }
+        #endregion
+        #endregion
+
+        #region Helpers
+        private void ValidateSiteUrl(SEOSettingsPart part)
+        {
+            if (string.IsNullOrWhiteSpace(part.RedirectToSiteUrl))
+                return;
+
+            var url = part.RedirectToSiteUrl;
+
+            // We need to ensure that this will parse as a URI so prepend a URL scheme
+            if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) && !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                url = (part.ForceSSL ? "https://" : "http://") + url.TrimStart('/');
+
+            part.RedirectToSiteUrl = url;
+        }
+
+        private void ValidateSiteUrlAndWWWCompatibility(SEOSettingsPart part, IUpdateModel updater)
+        {
+            if (string.IsNullOrWhiteSpace(part.RedirectToSiteUrl))
+                return;
+
+            if ("RedirectToNonWWW".Equals(part.Redirect, StringComparison.OrdinalIgnoreCase) && part.RedirectToSiteUrl.Contains("www."))
+            {
+                updater.AddModelError("RedirectToSiteUrl", T("Incompatible settings of 'Redirect' and 'Redirect to Site URL' because URL contains 'www' which would be redirected away"));
+                return;
+            }
+
+            if ("RedirectToWWW".Equals(part.Redirect, StringComparison.OrdinalIgnoreCase) && !part.RedirectToSiteUrl.Contains("www."))
+            {
+                updater.AddModelError("RedirectToSiteUrl", T("Incompatible settings of 'Redirect' and 'Redirect to Site URL' because URL does not contain 'www' which would be redirected away"));
+            }
+        }
+        #endregion
     }
 }

--- a/Models/SEOSettingsPart.cs
+++ b/Models/SEOSettingsPart.cs
@@ -3,7 +3,8 @@ using Orchard.ContentManagement.FieldStorage.InfosetStorage;
 using System;
 using System.Collections.Generic;
 
-namespace Moov2.Orchard.SEO.Models {
+namespace Moov2.Orchard.SEO.Models
+{
     public class SEOSettingsPart : ContentPart {
         public const string CacheKey = "SEOSettingsPart";
 
@@ -48,6 +49,12 @@ namespace Moov2.Orchard.SEO.Models {
                 return !string.IsNullOrWhiteSpace(attributeValue) && Convert.ToBoolean(attributeValue);
             }
             set { this.As<InfosetPart>().Set<SEOSettingsPart>("RedirectToNonWWW", value.ToString()); }
+        }
+
+        public string RedirectToSiteUrl
+        {
+            get { return this.As<InfosetPart>().Get<SEOSettingsPart>("RedirectToSiteUrl"); }
+            set { this.As<InfosetPart>().Set<SEOSettingsPart>("RedirectToSiteUrl", value == null ? "" : value.ToString()); }
         }
 
         public string IgnoredUrls

--- a/Views/EditorTemplates/Parts.SEOSettings.cshtml
+++ b/Views/EditorTemplates/Parts.SEOSettings.cshtml
@@ -30,7 +30,8 @@
     <label for="@Html.FieldIdFor(m => m.RedirectToSiteUrl)">@T("Redirect to Site URL")</label>
     @Html.EditorFor(m => m.RedirectToSiteUrl)
     @Html.ValidationMessage("RedirectToSiteUrl", "*")
-    <span class="hint">@("Visitors to the site will be redirected to the specified URL above if they are not currently using that URL.")</span>
+    <span class="hint">@("WARNING: you could lose access to your site if you set this value incorrectly, consider adding an Ignored URL for your admin area.")</span>
+    <span class="hint">@("Visitors to the site will be redirected to the specified URL above with a 301 response if they are not currently using that URL. Their location within the site will not be affected.")</span>
     <span class="hint">@("Only supports changing the domain name and cannot clash with the WWW/none WWW setting above.")</span>
 </fieldset>
 

--- a/Views/EditorTemplates/Parts.SEOSettings.cshtml
+++ b/Views/EditorTemplates/Parts.SEOSettings.cshtml
@@ -27,6 +27,14 @@
 </fieldset>
 
 <fieldset>
+    <label for="@Html.FieldIdFor(m => m.RedirectToSiteUrl)">@T("Redirect to Site URL")</label>
+    @Html.EditorFor(m => m.RedirectToSiteUrl)
+    @Html.ValidationMessage("RedirectToSiteUrl", "*")
+    <span class="hint">@("Visitors to the site will be redirected to the specified URL above if they are not currently using that URL.")</span>
+    <span class="hint">@("Only supports changing the domain name and cannot clash with the WWW/none WWW setting above.")</span>
+</fieldset>
+
+<fieldset>
     @Html.EditorFor(m => m.ForceSSL)
     <label for="@Html.FieldIdFor(m => m.ForceSSL)" class="forcheckbox">@T("Force SSL")</label>
     @Html.ValidationMessage("ForceSSL", "*")
@@ -38,7 +46,7 @@
     @Html.TextAreaFor(m => m.IgnoredUrls)
     @Html.ValidationMessage("IgnoredUrls", "*")
     <span class="hint">@T("URLs that should be ignored by the redirect settings (ideal for handling staging slots within Azure). Use a new line to seperate each URL.")</span>
-</fieldset>    
+</fieldset>
 
 <hr />
 
@@ -64,7 +72,8 @@
 
 <hr />
 
-@if (isRobotsEnabled) {
+@if (isRobotsEnabled)
+{
     <h2>@T("Site Crawlers")</h2>
 
     <fieldset>
@@ -76,7 +85,8 @@
     <hr />
 }
 
-@if (isFaviconEnabled) {
+@if (isFaviconEnabled)
+{
     <h2>@T("Favicon")</h2>
 
     <fieldset class="js-favicon">


### PR DESCRIPTION
Adds a new setting to the SEO Settings page allowing the user to specify a 'Redirect to Site URL' which will cause a 301 redirect if a visitor is not currently matching that domain specified.

Has validation checks to ensure the value specified is compatible with the redirect www / not www setting and the Force SSL setting.

Implemented by adding to the `ConsistenUrlFilter` with another stage that compares the current URI to the `RedirectToSiteUrl`, if it finds they don't match it will update the `Host` of the current uri to the `Host` of the `RedirectToSiteUrl`. This means Visitors will remain at the same route in the site. This also means that the new setting will respect ignored URLs and is applied after www/non www and Force SSL.